### PR TITLE
Fix import issue for timeout.js on gnome 45.0

### DIFF
--- a/tailscale@joaophi.github.com/tailscale.js
+++ b/tailscale@joaophi.github.com/tailscale.js
@@ -3,7 +3,7 @@ import GObject from "gi://GObject";
 import Gio from "gi://Gio";
 import Soup from "gi://Soup?version=3.0";
 
-import { setTimeout } from "./timeout";
+import { setTimeout } from "./timeout.js";
 
 class TailscaleApiClient {
   constructor() {


### PR DESCRIPTION
Hey, thank you for this awesome extension. It worked like a breeze on my machine until the latest update. This tiny PR fixes it for me.

![tailscale_error](https://github.com/joaophi/tailscale-gnome-qs/assets/17786457/90f183dc-b354-458b-b4b3-f8cbf755e22a)
