### PR TITLE
Handle peers without Tags

### DIFF
--- a/tailscale@joaophi.github.com/tailscale.js
+++ b/tailscale@joaophi.github.com/tailscale.js
@@ -138,7 +138,7 @@ export const Tailscale = GObject.registerClass(
           exit_node_option: peer.ExitNodeOption,
           online: peer.Online,
           ips: peer.TailscaleIPs,
-          mullvad: peer.Tags.includes("tag:mullvad-exit-node"),
+          mullvad: peer.Tags?.includes("tag:mullvad-exit-node") || false,
         }))
         .sort((a, b) =>
           (b.exit_node - a.exit_node)


### PR DESCRIPTION
If a peer doesn't have any tags the previous detection for Mullvad would fail and the extension would show an empty node list and crash instead.