### PR TITLE
Fixed metedata to add GNOME 47 check

### DIFF
--- a/tailscale@joaophi.github.com/metadata.json
+++ b/tailscale@joaophi.github.com/metadata.json
@@ -4,7 +4,8 @@
   "uuid": "tailscale@joaophi.github.com",
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47"
   ],
   "url": "https://github.com/joaophi/tailscale-gnome-qs",
   "gettext-domain": "tailscale@joaophi.github.com"


### PR DESCRIPTION
Test and confirmed to work with GNOME 47 on fedora 41.