### PR TITLE
Add support to multiple accounts (tailscale profiles)

### DIFF
--- a/tailscale@joaophi.github.com/extension.js
+++ b/tailscale@joaophi.github.com/extension.js
@@ -262,7 +262,7 @@ const TailscaleMenuToggle = GObject.registerClass(
       const update_profiles = (obj) => {
         profiles.menu.removeAll();
         for (const p of obj.profiles) {
-          let enabled = obj._prefs.ControlURL === p.ControlURL;
+          let enabled = obj._prefs.ControlURL === p.ControlURL && obj._prefs.Config.UserProfile.ID === p.UserProfile.ID;
           const onClick = () => { tailscale.profiles = p.ID; }
           profiles.menu.addMenuItem(new TailscaleProfileItem(p.Name, p.NetworkProfile.DomainName, enabled, onClick));
         }

--- a/tailscale@joaophi.github.com/extension.js
+++ b/tailscale@joaophi.github.com/extension.js
@@ -153,6 +153,17 @@ const TailscaleProfileItem = GObject.registerClass(
   }
 );
 
+const PopupScrollableSubMenuMenuItem = GObject.registerClass(
+  class PopupScrollableSubMenuMenuItem extends PopupMenu.PopupSubMenuMenuItem {
+    _init(props) {
+      super._init(props);
+
+      this.menu._needsScrollbar = () => true;
+      this.menu.box.height = 200;
+    }
+  }
+);
+
 const TailscaleMenuToggle = GObject.registerClass(
   class TailscaleMenuToggle extends QuickSettings.QuickMenuToggle {
     _init(icon, tailscale) {
@@ -176,6 +187,7 @@ const TailscaleMenuToggle = GObject.registerClass(
       this.menu.setHeader(icon, this.title, tailscale.exit_node_name);
 
       // NODES
+      const mnodes = new PopupScrollableSubMenuMenuItem(_("Nodes"), false, {});
       const nodes = new PopupMenu.PopupMenuSection();
       const update_nodes = (obj) => {
         nodes.removeAll();
@@ -211,7 +223,8 @@ const TailscaleMenuToggle = GObject.registerClass(
       }
       tailscale.connect("notify::nodes", (obj) => update_nodes(obj));
       update_nodes(tailscale);
-      this.menu.addMenuItem(nodes);
+      mnodes.menu.addMenuItem(nodes);
+      this.menu.addMenuItem(mnodes);
 
       // SEPARATOR
       this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());

--- a/tailscale@joaophi.github.com/extension.js
+++ b/tailscale@joaophi.github.com/extension.js
@@ -136,11 +136,9 @@ const TailscaleProfileItem = GObject.registerClass(
       sub.text = subtitle;
 
       if (enabled) {
-        const icon = new St.Icon({
-          style_class: 'popup-menu-icon',
-        });
+        const icon = new St.Icon({ style_class: 'system-status-icon' });
         this.add_child(icon);
-        icon.icon_name = 'dialog-ok'
+        icon.icon_name = 'object-select-symbolic'
       }
 
       this.connect('activate', () => onClick());

--- a/tailscale@joaophi.github.com/extension.js
+++ b/tailscale@joaophi.github.com/extension.js
@@ -116,6 +116,43 @@ const TailscaleDeviceItem = GObject.registerClass(
   }
 );
 
+const TailscaleProfileItem = GObject.registerClass(
+  class TailscaleProfileItem extends PopupMenu.PopupBaseMenuItem {
+    _init(title, subtitle, enabled, onClick) {
+      super._init({
+        activate: onClick,
+      });
+
+      const label = new St.Label({
+        x_expand: true,
+      });
+      this.add_child(label);
+      label.text = title;
+
+      const sub = new St.Label({
+        style_class: 'device-subtitle',
+      });
+      this.add_child(sub);
+      sub.text = subtitle;
+
+      if (enabled) {
+        const icon = new St.Icon({
+          style_class: 'popup-menu-icon',
+        });
+        this.add_child(icon);
+        icon.icon_name = 'dialog-ok'
+      }
+
+      this.connect('activate', () => onClick());
+    }
+
+    activate(event) {
+      if (this._activatable)
+        this.emit('activate', event);
+    }
+  }
+);
+
 const TailscaleMenuToggle = GObject.registerClass(
   class TailscaleMenuToggle extends QuickSettings.QuickMenuToggle {
     _init(icon, tailscale) {
@@ -208,6 +245,20 @@ const TailscaleMenuToggle = GObject.registerClass(
       prefs.menu.addMenuItem(ssh);
 
       this.menu.addMenuItem(prefs);
+
+      // PROFILES
+      const profiles = new PopupMenu.PopupSubMenuMenuItem(_("Profiles"), false, {});
+      const update_profiles = (obj) => {
+        profiles.menu.removeAll();
+        for (const p of obj.profiles) {
+          let enabled = obj._prefs.ControlURL === p.ControlURL;
+          const onClick = () => { tailscale.profiles = p.ID; }
+          profiles.menu.addMenuItem(new TailscaleProfileItem(p.Name, p.NetworkProfile.DomainName, enabled, onClick));
+        }
+      }
+      tailscale.connect("notify::profiles", (obj) => update_profiles(obj));
+      update_nodes(tailscale);
+      this.menu.addMenuItem(profiles);
     }
   }
 );

--- a/tailscale@joaophi.github.com/locale/it.po
+++ b/tailscale@joaophi.github.com/locale/it.po
@@ -52,3 +52,8 @@ msgstr "Scudi alzati"
 #: extension.js:189
 msgid "SSH"
 msgstr "SSH"
+
+#: extension.js:276
+msgid "Profiles"
+msgstr "Profili"
+

--- a/tailscale@joaophi.github.com/locale/it.po
+++ b/tailscale@joaophi.github.com/locale/it.po
@@ -57,3 +57,5 @@ msgstr "SSH"
 msgid "Profiles"
 msgstr "Profili"
 
+msgid "Nodes"
+msgstr "Nodi"


### PR DESCRIPTION
This fixes issue #13 (Enchancement: Support for multiple accounts)

I added a submenu after "settings" with tailscale profiles list. OnClick event switches to selected profile.


![Schermata del 2024-10-24 23-25-40](https://github.com/user-attachments/assets/3d528a95-827a-4a50-be79-76426c672a2c)
