### PR TITLE
Added snap installation support

### DIFF
--- a/tailscale@joaophi.github.com/tailscale.js
+++ b/tailscale@joaophi.github.com/tailscale.js
@@ -7,8 +7,18 @@ import { setTimeout } from "./timeout.js";
 
 class TailscaleApiClient {
   constructor() {
+    const nativePath = "/var/run/tailscale/tailscaled.sock";
+    const snapPath = "/var/snap/tailscale/common/socket/tailscaled.sock";
+    let socketPath;
+    if (GLib.file_test(nativePath, GLib.FileTest.EXISTS)) {
+      socketPath = nativePath;
+    } else if (GLib.file_test(snapPath, GLib.FileTest.EXISTS)) {
+      socketPath = snapPath;
+    } else {
+      throw new Error("Cannot find tailscaled.sock in either standard or snap locations.");
+    }
     const address = new Gio.UnixSocketAddress({
-      path: "/var/run/tailscale/tailscaled.sock",
+      path: socketPath,
     });
     this.session = new Soup.Session({
       "remote-connectable": address,


### PR DESCRIPTION
The PR improves compatibility of the extension by allowing it to detect and use the correct tailscaled.sock socket path automatically, depending on how Tailscale is installed:
 - Native installation (apt/dnf):
   `/var/run/tailscale/tailscaled.sock`
 - Snap installation:
   `/var/snap/tailscale/common/socket/tailscaled.sock`  

The `TailscaleApiClient` constructor now:
 - Checks if the native socket path exists.
 - Falls back to the snap path if needed.
 - Throws an error if neither socket is found.