### PR TITLE
[Version Update] Fix plugin for Gnome 49 Compatibility

### DIFF
--- a/tailscale@joaophi.github.com/extension.js
+++ b/tailscale@joaophi.github.com/extension.js
@@ -82,8 +82,9 @@ const TailscaleDeviceItem = GObject.registerClass(
 
       this.connect('activate', () => onClick());
 
-      const clickAction = this._clickAction ?? (() => {
-        const action = new Clutter.ClickAction();
+      
+      const clickGesture = this._clickGesture ?? (() => {
+        const action = new Clutter.ClickGesture();
         this.add_action(action);
         action.connect('notify::pressed', () => {
           if (action.pressed)
@@ -91,16 +92,24 @@ const TailscaleDeviceItem = GObject.registerClass(
           else
             this.remove_style_pseudo_class('active');
         });
-        action.connect('clicked', () => this.activate(Clutter.get_current_event()));
+        action.connect('recognize', () => this.activate(Clutter.get_current_event()));
         return action
       })();
-      clickAction.connect('long-press', (_action, _actor, state) => {
-        if (state === Clutter.LongPressState.ACTIVATE) {
-          return onLongClick();
-        }
-        return true;
-      });
-      clickAction.enabled = true;
+      clickGesture.enabled = true;
+
+      const longPressGesture = this._longPressGesture ?? (() => {
+        const action = new Clutter.LongPressGesture();
+        this.add_action(action);
+        action.connect('notify::pressed', () => {
+          if (action.pressed)
+            this.add_style_pseudo_class('active');
+          else
+            this.remove_style_pseudo_class('active');
+        });
+        action.connect('recognize', () => onLongClick());
+        return action
+      })();
+      longPressGesture.enabled = true;
     }
 
     activate(event) {
@@ -207,7 +216,7 @@ const TailscaleMenuToggle = GObject.registerClass(
 
             St.Clipboard.get_default().set_text(St.ClipboardType.CLIPBOARD, node.ips[0]);
             St.Clipboard.get_default().set_text(St.ClipboardType.PRIMARY, node.ips[0]);
-            Main.osdWindowManager.show(-1, icon, _("IP address has been copied to the clipboard"));
+            Main.osdWindowManager.showAll(icon, _("IP address has been copied to the clipboard"));
             return true;
           };
 

--- a/tailscale@joaophi.github.com/metadata.json
+++ b/tailscale@joaophi.github.com/metadata.json
@@ -3,11 +3,9 @@
   "description": "Add Tailscale to GNOME quick settings\n\nMake sure you set your user as tailscale operator:\nsudo tailscale set --operator=$USER",
   "uuid": "tailscale@joaophi.github.com",
   "shell-version": [
-    "45",
-    "46",
-    "47",
-    "48"
+    "49"
   ],
   "url": "https://github.com/joaophi/tailscale-gnome-qs",
-  "gettext-domain": "tailscale@joaophi.github.com"
+  "gettext-domain": "tailscale@joaophi.github.com",
+  "version": "20"
 }


### PR DESCRIPTION
Unfortunately, the plugin used library versions that changed in Gnome 49, so this migrates to use the new methods.

* [`Clutter.ClickAction()` -> `Clutter.ClickGesture()` and `Clutter.LongPressGesture()`](https://gjs.guide/extensions/upgrading/gnome-shell-49.html#clutter)
* [`OsdWindowManager.show()` -> `OsdWindowManager.showAll()`](https://gjs.guide/extensions/upgrading/gnome-shell-49.html#osdwindowmanager)
* bump version number in metadata.json
This is intended to fix [Issue #43 ](https://github.com/joaophi/tailscale-gnome-qs/issues/43)